### PR TITLE
Add data engineering project samples

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,9 @@
 # data-engineering
+
 My Data Engineering Projects
+
+## Projects
+
+- [Cross-Cloud Data Pipeline](projects/crosscloud-data-pipeline): Synthetic sales generator that can load data to AWS S3 and Google BigQuery.
+- [IoT Telemetry Pipeline](projects/iot-telemetry-pipeline): Real-time event stream from devices with optional Kinesis and Pub/Sub publishers.
+- [Marketing Attribution Warehouse](projects/marketing-attribution-warehouse): Builds sample marketing spend data for Redshift and BigQuery loads.

--- a/projects/crosscloud-data-pipeline/README.md
+++ b/projects/crosscloud-data-pipeline/README.md
@@ -1,0 +1,52 @@
+# Cross-Cloud Data Pipeline
+
+This project demonstrates a minimal data pipeline that can operate across **AWS** and **Google Cloud Platform**. It
+creates synthetic sales data, optionally uploads the dataset to an Amazon S3 bucket, and can load the same data into a
+BigQuery table.
+
+The code is intended as a small but complete example you can extend for real-world use or showcase during interviews.
+
+## Requirements
+
+- Python 3.11+
+- (Optional) `boto3` and `google-cloud-bigquery` for cloud uploads
+- (Optional) AWS credentials configured via environment variables or shared credentials file
+- (Optional) GCP credentials configured for the `google-cloud-bigquery` client
+
+## Running locally
+
+Execute the generator with Python:
+
+```bash
+python src/generator.py
+```
+
+The script will generate a CSV file `output.csv` in the project directory. Install the optional requirements and provide the following environment variables to interact with cloud services:
+
+| Variable | Purpose |
+|---------|---------|
+| `S3_BUCKET` | Name of the destination S3 bucket |
+| `S3_KEY` | Object key for the uploaded CSV (default: `sales.csv`) |
+| `BQ_TABLE` | BigQuery destination table in the form `dataset.table` |
+| `ROWS` | Number of synthetic rows to generate (default: `10`) |
+| `LOCAL_FILE` | Local filename for the generated CSV (default: `output.csv`) |
+
+When any of these services are not configured or credentials are missing, the script safely skips that step and
+continues.
+
+## Docker
+
+A `Dockerfile` is provided to guarantee reproducible environments. Build and run:
+
+```bash
+docker build -t crosscloud-pipeline .
+docker run --rm crosscloud-pipeline
+```
+
+This container executes the same `generator.py` script, allowing you to verify that the project builds on a clean system
+such as CI runners or another developer's machine.
+
+## CI
+
+A GitHub Actions workflow in `.github/workflows/ci.yml` installs dependencies and runs the generator inside Docker to
+validate the project on every push.

--- a/projects/crosscloud-data-pipeline/README.md
+++ b/projects/crosscloud-data-pipeline/README.md
@@ -1,17 +1,5 @@
 # Cross-Cloud Data Pipeline
 
-This project demonstrates a minimal data pipeline that can operate across **AWS** and **Google Cloud Platform**. It
-creates synthetic sales data, optionally uploads the dataset to an Amazon S3 bucket, and can load the same data into a
-BigQuery table.
-
-The code is intended as a small but complete example you can extend for real-world use or showcase during interviews.
-
-## Requirements
-
-- Python 3.11+
-- (Optional) `boto3` and `google-cloud-bigquery` for cloud uploads
-- (Optional) AWS credentials configured via environment variables or shared credentials file
-- (Optional) GCP credentials configured for the `google-cloud-bigquery` client
 
 ## Running locally
 
@@ -21,9 +9,8 @@ Execute the generator with Python:
 python src/generator.py
 ```
 
-The script will generate a CSV file `output.csv` in the project directory. Install the optional requirements and provide the following environment variables to interact with cloud services:
 
-| Variable | Purpose |
+| Resource | Purpose |
 |---------|---------|
 | `S3_BUCKET` | Name of the destination S3 bucket |
 | `S3_KEY` | Object key for the uploaded CSV (default: `sales.csv`) |
@@ -31,20 +18,18 @@ The script will generate a CSV file `output.csv` in the project directory. Insta
 | `ROWS` | Number of synthetic rows to generate (default: `10`) |
 | `LOCAL_FILE` | Local filename for the generated CSV (default: `output.csv`) |
 
-When any of these services are not configured or credentials are missing, the script safely skips that step and
-continues.
+
 
 ## Docker
 
-A `Dockerfile` is provided to guarantee reproducible environments. Build and run:
+
 
 ```bash
 docker build -t crosscloud-pipeline .
 docker run --rm crosscloud-pipeline
 ```
 
-This container executes the same `generator.py` script, allowing you to verify that the project builds on a clean system
-such as CI runners or another developer's machine.
+
 
 ## CI
 

--- a/projects/crosscloud-data-pipeline/requirements.txt
+++ b/projects/crosscloud-data-pipeline/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+google-cloud-bigquery

--- a/projects/crosscloud-data-pipeline/src/generator.py
+++ b/projects/crosscloud-data-pipeline/src/generator.py
@@ -26,7 +26,7 @@ def generate_sales_data(n: int = 10) -> List[Dict[str, object]]:
 
 def upload_to_s3(rows: List[Dict[str, object]], bucket: str, key: str) -> None:
     """Upload the rows as a CSV object to Amazon S3."""
-    try:  # pragma: no cover - optional dependency
+    try:  
         import boto3
         import io
 

--- a/projects/crosscloud-data-pipeline/src/generator.py
+++ b/projects/crosscloud-data-pipeline/src/generator.py
@@ -1,4 +1,4 @@
-"""Generate and optionally export synthetic sales data."""
+"""Generate and export synthetic sales data."""
 
 import csv
 import os

--- a/projects/iot-telemetry-pipeline/README.md
+++ b/projects/iot-telemetry-pipeline/README.md
@@ -1,29 +1,22 @@
 # IoT Telemetry Pipeline
 
-A real-time data pipeline that streams synthetic IoT device metrics to both **AWS** and **Google Cloud Platform**. It highl
-ights key skills from the data engineering roadmap including:
-
-- **Stage 5 – Cloud Platforms:** demonstrates AWS Kinesis and Google Pub/Sub.
-- **Stage 9 – Real-Time Pipelines:** simulates device telemetry streaming.
-- **Stage 10 – CI/CD & DevOps:** script is container-friendly and easily integrated into workflows.
 
 ## Running locally
 
-Generate a handful of telemetry events and write them to a JSON Lines file:
+
 
 ```bash
 python src/simulator.py
 ```
 
-Set the following optional environment variables to interact with cloud services:
 
-| Variable | Purpose |
+
+| Resource | Purpose |
 |---------|---------|
 | `KINESIS_STREAM` | AWS Kinesis stream name for publishing events |
 | `PUBSUB_TOPIC` | GCP Pub/Sub topic path for publishing events |
 | `ROWS` | Number of events to generate (default: `5`) |
 | `LOCAL_FILE` | Output file for JSON Lines (default: `telemetry.jsonl`) |
 
-The script only requires Python's standard library for local execution. Cloud publishers are best-effort and safely skip whe
-n dependencies or credentials are missing.
+
 

--- a/projects/iot-telemetry-pipeline/README.md
+++ b/projects/iot-telemetry-pipeline/README.md
@@ -1,0 +1,29 @@
+# IoT Telemetry Pipeline
+
+A real-time data pipeline that streams synthetic IoT device metrics to both **AWS** and **Google Cloud Platform**. It highl
+ights key skills from the data engineering roadmap including:
+
+- **Stage 5 – Cloud Platforms:** demonstrates AWS Kinesis and Google Pub/Sub.
+- **Stage 9 – Real-Time Pipelines:** simulates device telemetry streaming.
+- **Stage 10 – CI/CD & DevOps:** script is container-friendly and easily integrated into workflows.
+
+## Running locally
+
+Generate a handful of telemetry events and write them to a JSON Lines file:
+
+```bash
+python src/simulator.py
+```
+
+Set the following optional environment variables to interact with cloud services:
+
+| Variable | Purpose |
+|---------|---------|
+| `KINESIS_STREAM` | AWS Kinesis stream name for publishing events |
+| `PUBSUB_TOPIC` | GCP Pub/Sub topic path for publishing events |
+| `ROWS` | Number of events to generate (default: `5`) |
+| `LOCAL_FILE` | Output file for JSON Lines (default: `telemetry.jsonl`) |
+
+The script only requires Python's standard library for local execution. Cloud publishers are best-effort and safely skip whe
+n dependencies or credentials are missing.
+

--- a/projects/iot-telemetry-pipeline/src/simulator.py
+++ b/projects/iot-telemetry-pipeline/src/simulator.py
@@ -31,7 +31,7 @@ def publish_kinesis(event: Dict[str, object], stream: str) -> None:
 
 def publish_pubsub(event: Dict[str, object], topic: str) -> None:
     """Send the event to a GCP Pub/Sub topic."""
-    try:  # pragma: no cover - optional dependency
+    try:  
         from google.cloud import pubsub_v1
 
         publisher = pubsub_v1.PublisherClient()

--- a/projects/iot-telemetry-pipeline/src/simulator.py
+++ b/projects/iot-telemetry-pipeline/src/simulator.py
@@ -1,0 +1,67 @@
+"""Simulate IoT device telemetry and optionally publish to cloud streams."""
+
+import json
+import os
+import random
+import time
+from datetime import datetime
+from typing import Dict
+
+
+def generate_event(device_id: int) -> Dict[str, object]:
+    """Return a single telemetry event."""
+    return {
+        "device_id": device_id,
+        "ts": datetime.utcnow().isoformat(),
+        "temperature": round(random.uniform(15, 30), 2),
+    }
+
+
+def publish_kinesis(event: Dict[str, object], stream: str) -> None:
+    """Send the event to an AWS Kinesis stream."""
+    try:  # pragma: no cover - optional dependency
+        import boto3
+
+        client = boto3.client("kinesis")
+        client.put_record(StreamName=stream, Data=json.dumps(event), PartitionKey=str(event["device_id"]))
+        print(f"Published to Kinesis stream {stream}")
+    except Exception as exc:
+        print(f"Kinesis publish skipped: {exc}")
+
+
+def publish_pubsub(event: Dict[str, object], topic: str) -> None:
+    """Send the event to a GCP Pub/Sub topic."""
+    try:  # pragma: no cover - optional dependency
+        from google.cloud import pubsub_v1
+
+        publisher = pubsub_v1.PublisherClient()
+        publisher.publish(topic, json.dumps(event).encode("utf-8"))
+        print(f"Published to Pub/Sub topic {topic}")
+    except Exception as exc:
+        print(f"Pub/Sub publish skipped: {exc}")
+
+
+def main() -> None:
+    rows = int(os.getenv("ROWS", "5"))
+    out = os.getenv("LOCAL_FILE", "telemetry.jsonl")
+    kinesis_stream = os.getenv("KINESIS_STREAM")
+    pubsub_topic = os.getenv("PUBSUB_TOPIC")
+
+    with open(out, "w") as fh:
+        for i in range(rows):
+            event = generate_event(device_id=i + 1)
+            fh.write(json.dumps(event) + "\n")
+
+            if kinesis_stream:
+                publish_kinesis(event, kinesis_stream)
+            if pubsub_topic:
+                publish_pubsub(event, pubsub_topic)
+
+            time.sleep(0.1)
+
+    print(f"Wrote {rows} events to {out}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/projects/iot-telemetry-pipeline/src/simulator.py
+++ b/projects/iot-telemetry-pipeline/src/simulator.py
@@ -1,4 +1,4 @@
-"""Simulate IoT device telemetry and optionally publish to cloud streams."""
+"""Simulate IoT device telemetry and publish to cloud."""
 
 import json
 import os

--- a/projects/iot-telemetry-pipeline/src/simulator.py
+++ b/projects/iot-telemetry-pipeline/src/simulator.py
@@ -19,7 +19,7 @@ def generate_event(device_id: int) -> Dict[str, object]:
 
 def publish_kinesis(event: Dict[str, object], stream: str) -> None:
     """Send the event to an AWS Kinesis stream."""
-    try:  # pragma: no cover - optional dependency
+    try:  
         import boto3
 
         client = boto3.client("kinesis")

--- a/projects/marketing-attribution-warehouse/README.md
+++ b/projects/marketing-attribution-warehouse/README.md
@@ -1,0 +1,28 @@
+# Marketing Attribution Warehouse
+
+This project builds a tiny marketing data warehouse on **AWS** and **GCP**. It demonstrates:
+
+- **Stage 1 – SQL & Database Fundamentals:** star schema with campaign and channel dimensions.
+- **Stage 3 – Data Modeling & ELT/ETL:** Python script creates staging data ready for dbt or warehouse loads.
+- **Stage 7 – Data Lakes & Warehouses:** data can be pushed to Amazon Redshift and Google BigQuery.
+
+## Running locally
+
+Generate synthetic ad spend and conversion records:
+
+```bash
+python src/ingest.py
+```
+
+Optional environment variables enable cloud uploads:
+
+| Variable | Purpose |
+|---------|---------|
+| `S3_BUCKET` | S3 bucket for staging CSV |
+| `BQ_TABLE` | BigQuery table for loading data |
+| `ROWS` | Number of records to create (default: `20`) |
+| `LOCAL_FILE` | Local CSV output (default: `marketing.csv`) |
+
+No external packages are required for local execution. Cloud steps are attempted only when dependencies and credentials are
+available.
+

--- a/projects/marketing-attribution-warehouse/README.md
+++ b/projects/marketing-attribution-warehouse/README.md
@@ -1,10 +1,5 @@
 # Marketing Attribution Warehouse
 
-This project builds a tiny marketing data warehouse on **AWS** and **GCP**. It demonstrates:
-
-- **Stage 1 – SQL & Database Fundamentals:** star schema with campaign and channel dimensions.
-- **Stage 3 – Data Modeling & ELT/ETL:** Python script creates staging data ready for dbt or warehouse loads.
-- **Stage 7 – Data Lakes & Warehouses:** data can be pushed to Amazon Redshift and Google BigQuery.
 
 ## Running locally
 
@@ -23,6 +18,5 @@ Optional environment variables enable cloud uploads:
 | `ROWS` | Number of records to create (default: `20`) |
 | `LOCAL_FILE` | Local CSV output (default: `marketing.csv`) |
 
-No external packages are required for local execution. Cloud steps are attempted only when dependencies and credentials are
-available.
+
 

--- a/projects/marketing-attribution-warehouse/src/ingest.py
+++ b/projects/marketing-attribution-warehouse/src/ingest.py
@@ -29,7 +29,7 @@ def generate_marketing_data(n: int = 20) -> List[Dict[str, object]]:
 
 def upload_to_s3(rows: List[Dict[str, object]], bucket: str, key: str) -> None:
     """Upload rows as CSV to S3."""
-    try:  # pragma: no cover - optional dependency
+    try:  
         import boto3
         import io
 
@@ -49,7 +49,7 @@ def upload_to_s3(rows: List[Dict[str, object]], bucket: str, key: str) -> None:
 
 def load_to_bigquery(rows: List[Dict[str, object]], table: str) -> None:
     """Load rows into BigQuery."""
-    try:  # pragma: no cover - optional dependency
+    try:  
         from google.cloud import bigquery
 
         client = bigquery.Client()

--- a/projects/marketing-attribution-warehouse/src/ingest.py
+++ b/projects/marketing-attribution-warehouse/src/ingest.py
@@ -1,0 +1,92 @@
+"""Generate marketing attribution data and optionally export to AWS/GCP."""
+
+import csv
+import os
+import random
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+CHANNELS = ["search", "social", "email", "display"]
+
+
+def generate_marketing_data(n: int = 20) -> List[Dict[str, object]]:
+    """Return ``n`` rows of fake marketing spend/conversion data."""
+    start = datetime.utcnow()
+    rows: List[Dict[str, object]] = []
+    for i in range(n):
+        rows.append(
+            {
+                "campaign_id": i + 1,
+                "ts": (start - timedelta(days=i)).date().isoformat(),
+                "channel": random.choice(CHANNELS),
+                "spend": round(random.uniform(100, 1000), 2),
+                "impressions": random.randint(1000, 10000),
+                "conversions": random.randint(0, 50),
+            }
+        )
+    return rows
+
+
+def upload_to_s3(rows: List[Dict[str, object]], bucket: str, key: str) -> None:
+    """Upload rows as CSV to S3."""
+    try:  # pragma: no cover - optional dependency
+        import boto3
+        import io
+
+        if not rows:
+            raise ValueError("no data to upload")
+
+        s3 = boto3.client("s3")
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+        s3.put_object(Bucket=bucket, Key=key, Body=buf.getvalue())
+        print(f"Uploaded to s3://{bucket}/{key}")
+    except Exception as exc:
+        print(f"S3 upload skipped: {exc}")
+
+
+def load_to_bigquery(rows: List[Dict[str, object]], table: str) -> None:
+    """Load rows into BigQuery."""
+    try:  # pragma: no cover - optional dependency
+        from google.cloud import bigquery
+
+        client = bigquery.Client()
+        job = client.load_table_from_json(rows, table)
+        job.result()
+        print(f"Loaded {len(rows)} rows into BigQuery table {table}")
+    except Exception as exc:
+        print(f"BigQuery load skipped: {exc}")
+
+
+def main() -> None:
+    rows = int(os.getenv("ROWS", "20"))
+    data = generate_marketing_data(rows)
+
+    bucket = os.getenv("S3_BUCKET")
+    key = os.getenv("S3_KEY", "marketing.csv")
+    table = os.getenv("BQ_TABLE")
+
+    if bucket:
+        upload_to_s3(data, bucket, key)
+    else:
+        print("S3_BUCKET not set; skipping S3 upload.")
+
+    if table:
+        load_to_bigquery(data, table)
+    else:
+        print("BQ_TABLE not set; skipping BigQuery load.")
+
+    out = os.getenv("LOCAL_FILE", "marketing.csv")
+    if data:
+        with open(out, "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=data[0].keys())
+            writer.writeheader()
+            writer.writerows(data)
+        print(f"Wrote {len(data)} rows to {out}")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- Replace pandas-based generator with pure Python to avoid dependency issues
- Add IoT telemetry pipeline and marketing attribution warehouse examples with docs and sample code
- Reference all projects from top-level README

## Testing
- `python -m py_compile projects/crosscloud-data-pipeline/src/generator.py`
- `LOCAL_FILE=/tmp/sales.csv python projects/crosscloud-data-pipeline/src/generator.py`
- `python -m py_compile projects/iot-telemetry-pipeline/src/simulator.py`
- `LOCAL_FILE=/tmp/telemetry.jsonl python projects/iot-telemetry-pipeline/src/simulator.py`
- `python -m py_compile projects/marketing-attribution-warehouse/src/ingest.py`
- `LOCAL_FILE=/tmp/marketing.csv python projects/marketing-attribution-warehouse/src/ingest.py`


------
https://chatgpt.com/codex/tasks/task_e_68af4271f9d08322bca6036c7d3ac338