### PR TITLE
docs: rename variables to resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,5 +10,5 @@ Hi there! This repo is my sandbox of miniature data projects. Each folder tells 
 | [IoT Telemetry Pipeline](projects/iot-telemetry-pipeline) | Fakes sensor readings, streams to Kinesis/Pub/Sub, and reports average temperature. | AWS + GCP |
 | [Marketing Attribution Warehouse](projects/marketing-attribution-warehouse) | Generates ad spend records, computes CPA, and summarizes by channel. | AWS + GCP |
 
-Clone the repo, pick a project, and run `watch*` to run the script.
+Clone the repo, pick a project, and run the script.
 Built for curious recruiters and hiring managers—reach out if you'd like a tour of any example!

--- a/README.md
+++ b/README.md
@@ -1,2 +1,15 @@
-# data-engineering
-My Data Engineering Projects
+# Data Engineering Portfolio
+
+Hi there! This repo is my sandbox of miniature data projects. Each folder tells a tiny story you can run in minutes and chat through with a recruiter or hiring manager.
+
+## Projects at a glance
+
+| Project | What you'll see | Cloud coverage |
+| --- | --- | --- |
+| [Cross-Cloud Data Pipeline](projects/crosscloud-data-pipeline) | Pushes one sales dataset to S3 & BigQuery and outputs store revenue totals. Terraform and Docker optional. | AWS + GCP |
+| [IoT Telemetry Pipeline](projects/iot-telemetry-pipeline) | Fakes sensor readings, streams to Kinesis/Pub/Sub, and reports average temperature. | AWS + GCP |
+| [Marketing Attribution Warehouse](projects/marketing-attribution-warehouse) | Generates ad spend records, computes CPA, and summarizes by channel. | AWS + GCP |
+
+Clone the repo, pick a project, and run `watch*` to run the script.
+---
+Built for curious recruiters and hiring managers—reach out if you'd like a tour of any example!

--- a/README.md
+++ b/README.md
@@ -11,5 +11,4 @@ Hi there! This repo is my sandbox of miniature data projects. Each folder tells 
 | [Marketing Attribution Warehouse](projects/marketing-attribution-warehouse) | Generates ad spend records, computes CPA, and summarizes by channel. | AWS + GCP |
 
 Clone the repo, pick a project, and run `watch*` to run the script.
----
 Built for curious recruiters and hiring managers—reach out if you'd like a tour of any example!

--- a/projects/crosscloud-data-pipeline/README.docker.md
+++ b/projects/crosscloud-data-pipeline/README.docker.md
@@ -1,5 +1,5 @@
-Docker-based verification (use if local installs act up)
-------------------------------------------------------
+Use this Docker-based verification (use if local pip builds fail on Windows)
+---------------------------------------------------------------
 
 ### Why
 Windows can be picky about compiling Python packages. If a local install gives you trouble, run the project inside the provided Docker image so you know you're starting from a clean Linux environment.

--- a/projects/crosscloud-data-pipeline/README.docker.md
+++ b/projects/crosscloud-data-pipeline/README.docker.md
@@ -1,16 +1,15 @@
-Docker-based verification (use if local pip builds fail on Windows)
----------------------------------------------------------------
+Docker-based verification (use if local installs act up)
+------------------------------------------------------
 
-Why
-----
-Some Python packages (pandas, numpy extensions) may need compilation on Windows and require Visual Studio build tools. To avoid local build issues, we provide a Dockerfile and a CI workflow that builds and runs the project in a clean Ubuntu environment.
+### Why
+Windows can be picky about compiling Python packages. If a local install gives you trouble, run the project inside the provided Docker image so you know you're starting from a clean Linux environment.
 
-Quick local test (requires Docker Desktop):
-
+### Quick local test (requires Docker Desktop)
 ```bash
 cd projects/crosscloud-data-pipeline
 docker build -t crosscloud-pipeline:local .
 docker run --rm crosscloud-pipeline:local python src/generator.py
 ```
 
-This replicates what the CI will do on GitHub Actions and ensures the project is buildable in a clean Linux environment.
+This mirrors what GitHub Actions does and proves the project builds cleanly in a vanilla container.
+

--- a/projects/crosscloud-data-pipeline/README.md
+++ b/projects/crosscloud-data-pipeline/README.md
@@ -1,0 +1,54 @@
+# Cross-Cloud Data Pipeline
+
+Retail teams rarely live in a single cloud. This mini project shows how one tiny Python script can send the exact same dataset to both AWS and GCP without touching the business logic.
+
+## Highlights
+
+- Generates synthetic point‑of‑sale data with plain Python.
+- Uploads the CSV to Amazon S3 or loads it straight into Google BigQuery when credentials are present.
+- Computes store-level revenue totals and writes them to `summary.csv`.
+- Optional Terraform module stands up the demo bucket and dataset.
+- Dockerfile lets you run the pipeline in a clean container.
+
+## Run it
+
+```bash
+python src/generator.py
+```
+
+By default a file named `output.csv` appears locally. Add environment resources to reach the cloud:
+
+| Resource | Purpose |
+|---------|---------|
+| `S3_BUCKET` | S3 bucket to upload the CSV |
+| `S3_KEY` | Object key in S3 (default: `sales.csv`) |
+| `BQ_TABLE` | BigQuery table in `dataset.table` format |
+| `ROWS` | Number of rows to create (default: `10`) |
+| `LOCAL_FILE` | Name of the local CSV (default: `output.csv`) |
+
+No credentials? The script simply keeps everything on disk and produces a `summary.csv` with revenue totals per store.
+
+## Infrastructure
+
+Terraform files in [`terraform`](terraform) create the S3 bucket and BigQuery dataset/table.
+
+```bash
+cd terraform
+terraform init
+terraform plan
+```
+
+Apply the plan and re-run the generator pointing at the new resources.
+
+## Containers
+
+Build the image to simulate a fresh environment:
+
+```bash
+docker build -t crosscloud-pipeline .
+docker run --rm crosscloud-pipeline
+```
+
+## CI
+
+A GitHub Actions workflow builds the container and runs the generator on every push.

--- a/projects/crosscloud-data-pipeline/requirements.txt
+++ b/projects/crosscloud-data-pipeline/requirements.txt
@@ -1,0 +1,2 @@
+boto3
+google-cloud-bigquery

--- a/projects/crosscloud-data-pipeline/src/generator.py
+++ b/projects/crosscloud-data-pipeline/src/generator.py
@@ -1,0 +1,105 @@
+"""Generate and optionally export synthetic sales data."""
+
+import csv
+import os
+import random
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+
+def generate_sales_data(n: int = 10) -> List[Dict[str, object]]:
+    """Return ``n`` rows of fake sales data as dictionaries."""
+    now = datetime.utcnow()
+    rows: List[Dict[str, object]] = []
+    for i in range(n):
+        rows.append(
+            {
+                "sale_id": i + 1,
+                "ts": (now - timedelta(minutes=i)).isoformat(),
+                "store_id": random.randint(1, 3),
+                "product_id": random.randint(100, 105),
+                "price": round(random.uniform(10, 200), 2),
+            }
+        )
+    return rows
+
+
+def summarize_by_store(rows: List[Dict[str, object]]) -> List[Dict[str, object]]:
+    """Aggregate total revenue per ``store_id``."""
+    totals: Dict[int, float] = {}
+    for row in rows:
+        store = int(row["store_id"])
+        totals[store] = totals.get(store, 0.0) + float(row["price"])
+    return [{"store_id": s, "revenue": round(v, 2)} for s, v in totals.items()]
+
+
+def upload_to_s3(rows: List[Dict[str, object]], bucket: str, key: str) -> None:
+    """Upload the rows as a CSV object to Amazon S3."""
+    try:  # pragma: no cover - optional dependency
+        import boto3
+        import io
+
+        if not rows:
+            raise ValueError("no data to upload")
+
+        s3 = boto3.client("s3")
+        csv_buffer = io.StringIO()
+        writer = csv.DictWriter(csv_buffer, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+        s3.put_object(Bucket=bucket, Key=key, Body=csv_buffer.getvalue())
+        print(f"Uploaded to s3://{bucket}/{key}")
+    except Exception as exc:
+        print(f"S3 upload skipped: {exc}")
+
+
+def load_to_bigquery(rows: List[Dict[str, object]], table: str) -> None:
+    """Load rows into a BigQuery table using the JSON API."""
+    try:  # pragma: no cover - optional dependency
+        from google.cloud import bigquery
+
+        client = bigquery.Client()
+        job = client.load_table_from_json(rows, table)
+        job.result()
+        print(f"Loaded {len(rows)} rows into BigQuery table {table}")
+    except Exception as exc:
+        print(f"BigQuery load skipped: {exc}")
+
+
+def main() -> None:
+    rows = int(os.getenv("ROWS", "10"))
+    data = generate_sales_data(rows)
+
+    bucket = os.getenv("S3_BUCKET")
+    key = os.getenv("S3_KEY", "sales.csv")
+    table = os.getenv("BQ_TABLE")
+
+    if bucket:
+        upload_to_s3(data, bucket, key)
+    else:
+        print("S3_BUCKET not set; skipping S3 upload.")
+
+    if table:
+        load_to_bigquery(data, table)
+    else:
+        print("BQ_TABLE not set; skipping BigQuery load.")
+
+    out = os.getenv("LOCAL_FILE", "output.csv")
+    if data:
+        with open(out, "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=data[0].keys())
+            writer.writeheader()
+            writer.writerows(data)
+        print(f"Wrote {len(data)} rows to {out}")
+
+        summary = summarize_by_store(data)
+        with open("summary.csv", "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=["store_id", "revenue"])
+            writer.writeheader()
+            writer.writerows(summary)
+        print("Wrote store-level revenue summary to summary.csv")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/projects/crosscloud-data-pipeline/terraform/main.tf
+++ b/projects/crosscloud-data-pipeline/terraform/main.tf
@@ -1,0 +1,65 @@
+terraform {
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+    google = {
+      source  = "hashicorp/google"
+      version = "~> 5.0"
+    }
+  }
+}
+
+provider "aws" {
+  region = var.aws_region
+}
+
+provider "google" {
+  project = var.gcp_project
+  region  = var.gcp_region
+}
+
+resource "aws_s3_bucket" "sales" {
+  bucket        = var.s3_bucket
+  force_destroy = true
+}
+
+resource "google_bigquery_dataset" "sales" {
+  dataset_id = var.bq_dataset
+  location   = var.gcp_region
+}
+
+resource "google_bigquery_table" "sales" {
+  dataset_id          = google_bigquery_dataset.sales.dataset_id
+  table_id            = var.bq_table
+  deletion_protection = false
+
+  schema = jsonencode([
+    {
+      name = "order_id"
+      type = "STRING"
+      mode = "REQUIRED"
+    },
+    {
+      name = "order_date"
+      type = "DATE"
+      mode = "REQUIRED"
+    },
+    {
+      name = "customer_id"
+      type = "STRING"
+      mode = "REQUIRED"
+    },
+    {
+      name = "product"
+      type = "STRING"
+      mode = "REQUIRED"
+    },
+    {
+      name = "amount"
+      type = "FLOAT"
+      mode = "REQUIRED"
+    }
+  ])
+}

--- a/projects/crosscloud-data-pipeline/terraform/outputs.tf
+++ b/projects/crosscloud-data-pipeline/terraform/outputs.tf
@@ -1,0 +1,9 @@
+output "s3_bucket_name" {
+  description = "Provisioned S3 bucket"
+  value       = aws_s3_bucket.sales.bucket
+}
+
+output "bigquery_table" {
+  description = "Full BigQuery table name"
+  value       = "${google_bigquery_dataset.sales.dataset_id}.${google_bigquery_table.sales.table_id}"
+}

--- a/projects/crosscloud-data-pipeline/terraform/variables.tf
+++ b/projects/crosscloud-data-pipeline/terraform/variables.tf
@@ -1,0 +1,31 @@
+variable "aws_region" {
+  description = "AWS region for resources"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "gcp_project" {
+  description = "GCP project ID"
+  type        = string
+}
+
+variable "gcp_region" {
+  description = "GCP region"
+  type        = string
+  default     = "us-central1"
+}
+
+variable "s3_bucket" {
+  description = "Name of S3 bucket for sales data"
+  type        = string
+}
+
+variable "bq_dataset" {
+  description = "BigQuery dataset ID"
+  type        = string
+}
+
+variable "bq_table" {
+  description = "BigQuery table ID"
+  type        = string
+}

--- a/projects/iot-telemetry-pipeline/README.md
+++ b/projects/iot-telemetry-pipeline/README.md
@@ -1,0 +1,28 @@
+# IoT Telemetry Pipeline
+
+Pretend you have a fleet of sensors pinging back temperature readings. This tiny project fakes those events so you can chat about streaming architectures without spinning up real hardware.
+
+## Highlights
+
+- Emits JSON Lines events to a local file for quick inspection.
+- Can stream the same events to Amazon Kinesis or Google Pub/Sub when credentials are present.
+- Pure Python and tiny—perfect for demos or coding exercises.
+- Computes the average temperature and writes it to `summary.json`.
+
+## Run it
+
+```bash
+python src/simulator.py
+```
+
+A file named `telemetry.jsonl` appears with five events. Tune the behaviour with environment resources:
+
+| Resource | Purpose |
+|---------|---------|
+| `KINESIS_STREAM` | AWS Kinesis stream name |
+| `PUBSUB_TOPIC` | GCP Pub/Sub topic path |
+| `ROWS` | Number of events (default: `5`) |
+| `LOCAL_FILE` | Output file name (default: `telemetry.jsonl`) |
+| `SUMMARY_FILE` | Where to write the JSON summary (default: `summary.json`) |
+
+Missing credentials or libraries? The script simply writes the events and summary to local files.

--- a/projects/iot-telemetry-pipeline/src/simulator.py
+++ b/projects/iot-telemetry-pipeline/src/simulator.py
@@ -1,0 +1,73 @@
+"""Simulate IoT device telemetry and optionally publish to cloud streams."""
+
+import json
+import os
+import random
+import time
+from datetime import datetime
+from typing import Dict, List
+
+
+def generate_event(device_id: int) -> Dict[str, object]:
+    """Return a single telemetry event."""
+    return {
+        "device_id": device_id,
+        "ts": datetime.utcnow().isoformat(),
+        "temperature": round(random.uniform(15, 30), 2),
+    }
+
+
+def publish_kinesis(event: Dict[str, object], stream: str) -> None:
+    """Send the event to an AWS Kinesis stream."""
+    try:  # pragma: no cover - optional dependency
+        import boto3
+
+        client = boto3.client("kinesis")
+        client.put_record(StreamName=stream, Data=json.dumps(event), PartitionKey=str(event["device_id"]))
+        print(f"Published to Kinesis stream {stream}")
+    except Exception as exc:
+        print(f"Kinesis publish skipped: {exc}")
+
+
+def publish_pubsub(event: Dict[str, object], topic: str) -> None:
+    """Send the event to a GCP Pub/Sub topic."""
+    try:  # pragma: no cover - optional dependency
+        from google.cloud import pubsub_v1
+
+        publisher = pubsub_v1.PublisherClient()
+        publisher.publish(topic, json.dumps(event).encode("utf-8"))
+        print(f"Published to Pub/Sub topic {topic}")
+    except Exception as exc:
+        print(f"Pub/Sub publish skipped: {exc}")
+
+
+def main() -> None:
+    rows = int(os.getenv("ROWS", "5"))
+    out = os.getenv("LOCAL_FILE", "telemetry.jsonl")
+    summary_file = os.getenv("SUMMARY_FILE", "summary.json")
+    kinesis_stream = os.getenv("KINESIS_STREAM")
+    pubsub_topic = os.getenv("PUBSUB_TOPIC")
+
+    events: List[Dict[str, object]] = []
+    with open(out, "w") as fh:
+        for i in range(rows):
+            event = generate_event(device_id=i + 1)
+            events.append(event)
+            fh.write(json.dumps(event) + "\n")
+
+            if kinesis_stream:
+                publish_kinesis(event, kinesis_stream)
+            if pubsub_topic:
+                publish_pubsub(event, pubsub_topic)
+
+            time.sleep(0.1)
+
+    avg = round(sum(e["temperature"] for e in events) / len(events), 2) if events else 0.0
+    with open(summary_file, "w") as fh:
+        json.dump({"events": len(events), "avg_temperature": avg}, fh)
+    print(f"Wrote {rows} events to {out} and summary to {summary_file}")
+
+
+if __name__ == "__main__":
+    main()
+

--- a/projects/marketing-attribution-warehouse/README.md
+++ b/projects/marketing-attribution-warehouse/README.md
@@ -1,0 +1,27 @@
+# Marketing Attribution Warehouse
+
+Think of this as a tiny marketing warehouse. It fabricates campaign spend and conversion events so you can explore dimensional modeling and ELT patterns in the cloud.
+
+## Highlights
+
+- Generates sample marketing spend and conversion events.
+- Can stage the CSV to Amazon S3 or load directly into Google BigQuery.
+- Calculates cost-per-acquisition (CPA) per campaign and writes a channel summary to `summary.csv`.
+- Friendly starting point for conversations about star schemas and incremental loads.
+
+## Run it
+
+```bash
+python src/ingest.py
+```
+
+You'll get a `marketing.csv` file with twenty rows. The environment resources below let you send the data to the cloud:
+
+| Resource | Purpose |
+|---------|---------|
+| `S3_BUCKET` | S3 bucket for staging CSV |
+| `BQ_TABLE` | BigQuery table destination |
+| `ROWS` | Number of records to create (default: `20`) |
+| `LOCAL_FILE` | Local CSV name (default: `marketing.csv`) |
+
+If a dependency or credential is missing, the script just keeps everything local while still producing the `summary.csv`.

--- a/projects/marketing-attribution-warehouse/src/ingest.py
+++ b/projects/marketing-attribution-warehouse/src/ingest.py
@@ -1,0 +1,127 @@
+"""Generate marketing attribution data and optionally export to AWS/GCP."""
+
+import csv
+import os
+import random
+from datetime import datetime, timedelta
+from typing import Dict, List
+
+CHANNELS = ["search", "social", "email", "display"]
+
+
+def generate_marketing_data(n: int = 20) -> List[Dict[str, object]]:
+    """Return ``n`` rows of fake marketing spend/conversion data."""
+    start = datetime.utcnow()
+    rows: List[Dict[str, object]] = []
+    for i in range(n):
+        conversions = random.randint(0, 50)
+        spend = round(random.uniform(100, 1000), 2)
+        cpa = round(spend / conversions, 2) if conversions else None
+        rows.append(
+            {
+                "campaign_id": i + 1,
+                "ts": (start - timedelta(days=i)).date().isoformat(),
+                "channel": random.choice(CHANNELS),
+                "spend": spend,
+                "impressions": random.randint(1000, 10000),
+                "conversions": conversions,
+                "cpa": cpa,
+            }
+        )
+    return rows
+
+
+def summarize_by_channel(rows: List[Dict[str, object]]) -> List[Dict[str, object]]:
+    """Return aggregated spend/conversions per channel with CPA."""
+    totals: Dict[str, Dict[str, float]] = {}
+    for row in rows:
+        channel = str(row["channel"])
+        if channel not in totals:
+            totals[channel] = {"spend": 0.0, "conversions": 0.0}
+        totals[channel]["spend"] += float(row["spend"])
+        totals[channel]["conversions"] += float(row["conversions"])
+    summary: List[Dict[str, object]] = []
+    for channel, vals in totals.items():
+        conversions = vals["conversions"]
+        cpa = round(vals["spend"] / conversions, 2) if conversions else None
+        summary.append(
+            {
+                "channel": channel,
+                "spend": round(vals["spend"], 2),
+                "conversions": int(conversions),
+                "cpa": cpa,
+            }
+        )
+    return summary
+
+
+def upload_to_s3(rows: List[Dict[str, object]], bucket: str, key: str) -> None:
+    """Upload rows as CSV to S3."""
+    try:  # pragma: no cover - optional dependency
+        import boto3
+        import io
+
+        if not rows:
+            raise ValueError("no data to upload")
+
+        s3 = boto3.client("s3")
+        buf = io.StringIO()
+        writer = csv.DictWriter(buf, fieldnames=rows[0].keys())
+        writer.writeheader()
+        writer.writerows(rows)
+        s3.put_object(Bucket=bucket, Key=key, Body=buf.getvalue())
+        print(f"Uploaded to s3://{bucket}/{key}")
+    except Exception as exc:
+        print(f"S3 upload skipped: {exc}")
+
+
+def load_to_bigquery(rows: List[Dict[str, object]], table: str) -> None:
+    """Load rows into BigQuery."""
+    try:  # pragma: no cover - optional dependency
+        from google.cloud import bigquery
+
+        client = bigquery.Client()
+        job = client.load_table_from_json(rows, table)
+        job.result()
+        print(f"Loaded {len(rows)} rows into BigQuery table {table}")
+    except Exception as exc:
+        print(f"BigQuery load skipped: {exc}")
+
+
+def main() -> None:
+    rows = int(os.getenv("ROWS", "20"))
+    data = generate_marketing_data(rows)
+
+    bucket = os.getenv("S3_BUCKET")
+    key = os.getenv("S3_KEY", "marketing.csv")
+    table = os.getenv("BQ_TABLE")
+
+    if bucket:
+        upload_to_s3(data, bucket, key)
+    else:
+        print("S3_BUCKET not set; skipping S3 upload.")
+
+    if table:
+        load_to_bigquery(data, table)
+    else:
+        print("BQ_TABLE not set; skipping BigQuery load.")
+
+    out = os.getenv("LOCAL_FILE", "marketing.csv")
+    if data:
+        with open(out, "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=data[0].keys())
+            writer.writeheader()
+            writer.writerows(data)
+        print(f"Wrote {len(data)} rows to {out}")
+
+        summary = summarize_by_channel(data)
+        with open("summary.csv", "w", newline="") as fh:
+            writer = csv.DictWriter(fh, fieldnames=["channel", "spend", "conversions", "cpa"])
+            writer.writeheader()
+            writer.writerows(summary)
+        print("Wrote channel summary to summary.csv")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- replace "environment variables" with "environment resources" across project READMEs
- revise root README run instructions to reference `watch*`

## Testing
- `python -m py_compile projects/crosscloud-data-pipeline/src/generator.py`
- `LOCAL_FILE=/tmp/sales.csv python projects/crosscloud-data-pipeline/src/generator.py`
- `python -m py_compile projects/iot-telemetry-pipeline/src/simulator.py`
- `LOCAL_FILE=/tmp/telemetry.jsonl python projects/iot-telemetry-pipeline/src/simulator.py`
- `python -m py_compile projects/marketing-attribution-warehouse/src/ingest.py`
- `LOCAL_FILE=/tmp/marketing.csv python projects/marketing-attribution-warehouse/src/ingest.py`
- `terraform fmt projects/crosscloud-data-pipeline/terraform/main.tf` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68af4271f9d08322bca6036c7d3ac338